### PR TITLE
FEA: Tensorboard support and new valid mode

### DIFF
--- a/textbox/config/configurator.py
+++ b/textbox/config/configurator.py
@@ -170,9 +170,6 @@ class Config(object):
             logger.warning('command line args [{}] will not be used in TextBox'.format(' '.join(unrecognized_args)))
         cmd_config_dict = self._convert_config_dict(cmd_config_dict)
 
-        if cmd_config_dict.get('load_experiment'):
-            cmd_config_dict['load_experiment'] = os.path.abspath(cmd_config_dict['load_experiment'])
-
         if 'task_type' in cmd_config_dict and cmd_config_dict['task_type'] not in [
             'unconditional', 'translation', 'summarization', 'attribute', 'multi_dialog', 'poem'
         ]:

--- a/textbox/config/configurator.py
+++ b/textbox/config/configurator.py
@@ -170,6 +170,9 @@ class Config(object):
             logger.warning('command line args [{}] will not be used in TextBox'.format(' '.join(unrecognized_args)))
         cmd_config_dict = self._convert_config_dict(cmd_config_dict)
 
+        if cmd_config_dict.get('load_experiment'):
+            cmd_config_dict['load_experiment'] = os.path.abspath(cmd_config_dict['load_experiment'])
+
         if 'task_type' in cmd_config_dict and cmd_config_dict['task_type'] not in [
             'unconditional', 'translation', 'summarization', 'attribute', 'multi_dialog', 'poem'
         ]:

--- a/textbox/evaluator/base_evaluator.py
+++ b/textbox/evaluator/base_evaluator.py
@@ -29,10 +29,10 @@ from textbox.evaluator.unique_evaluator import UniqueEvaluator
 from textbox.evaluator.rouge_evaluator import RougeEvaluator
 from textbox.evaluator.kb2text_evaluator import Kb2TextEvaluator
 
-evaluator_list = [
+evaluator_list = {
     'bleu', 'self_bleu', 'rouge', 'distinct', 'nll_test', 'avg_len', 'cider', 'chrf++', 'meteor', 'unique',
     'bert_score', 'kb2text'
-]
+}
 
 
 class BaseEvaluator():

--- a/textbox/model/abstract_generator.py
+++ b/textbox/model/abstract_generator.py
@@ -140,7 +140,7 @@ class GenerativeAdversarialNet(UnconditionalGenerator):
             eval_data (Corpus): Corpus class of the batch.
 
         Returns:
-            torch.FloatTensor: NLL_test of eval data
+            torch.FloatTensor: NLL_test of _eval data
         """
         raise NotImplementedError
 

--- a/textbox/properties/overall.yaml
+++ b/textbox/properties/overall.yaml
@@ -8,6 +8,7 @@ reproducibility: True
 data_path: 'dataset/'
 checkpoint_dir: 'saved/'
 generated_text_dir: 'generated/'
+tensorboard_dir: 'log/runs'
 
 # training settings
 epochs: 50
@@ -17,6 +18,7 @@ learning_rate: 0.001
 eval_step: 1
 stopping_step: 2
 grad_clip: 0.1
+valid_metrics: ["loss"]
 
 # evaluation settings
 metrics: ["bleu"]

--- a/textbox/properties/overall.yaml
+++ b/textbox/properties/overall.yaml
@@ -15,7 +15,7 @@ epochs: 50
 train_batch_size: 64
 learner: adam
 learning_rate: 0.001
-eval_step: 1
+eval_epoch: 1
 stopping_step: 2
 grad_clip: 0.1
 valid_metrics: ["loss"]

--- a/textbox/quick_start/quick_start.py
+++ b/textbox/quick_start/quick_start.py
@@ -72,6 +72,8 @@ def run_textbox(model=None, dataset=None, config_file_list=None, config_dict=Non
 
     if config['test_only']:
         logger.info('Test only')
+        if not config['load_experiment']:
+            logger.warning('Specific model file with "load_experiment" parameter.')
         test_result = trainer.evaluate(test_data, load_best_model=saved, model_file=config['load_experiment'])
     else:
         if config['load_experiment'] is not None and is_logger:

--- a/textbox/utils/__init__.py
+++ b/textbox/utils/__init__.py
@@ -1,10 +1,9 @@
 from textbox.utils.logger import init_logger
-from textbox.utils.utils import get_local_time, ensure_dir, get_model, get_trainer, \
-    early_stopping, init_seed
+from textbox.utils.utils import get_local_time, ensure_dir, get_model, get_trainer,  init_seed
 from textbox.utils.enum_type import *
 from textbox.utils.argument_list import *
 
 __all__ = [
-    'init_logger', 'get_local_time', 'ensure_dir', 'get_model', 'get_trainer', 'early_stopping', 'Enum', 'ModelType',
+    'init_logger', 'get_local_time', 'ensure_dir', 'get_model', 'get_trainer', 'Enum', 'ModelType',
     'init_seed', 'general_arguments', 'training_arguments', 'evaluation_arguments', 'dataset_arguments'
 ]

--- a/textbox/utils/__init__.py
+++ b/textbox/utils/__init__.py
@@ -1,9 +1,10 @@
-from textbox.utils.logger import init_logger
-from textbox.utils.utils import get_local_time, ensure_dir, get_model, get_trainer,  init_seed
+from textbox.utils.logger import init_logger, TensorboardWriter
+from textbox.utils.utils import get_local_time, ensure_dir, get_model, get_trainer, init_seed, Timer
 from textbox.utils.enum_type import *
 from textbox.utils.argument_list import *
 
 __all__ = [
-    'init_logger', 'get_local_time', 'ensure_dir', 'get_model', 'get_trainer', 'Enum', 'ModelType',
-    'init_seed', 'general_arguments', 'training_arguments', 'evaluation_arguments', 'dataset_arguments'
+    'init_logger', 'TensorboardWriter', 'get_local_time', 'ensure_dir', 'get_model', 'get_trainer',
+    'Enum', 'ModelType', 'init_seed', 'general_arguments', 'training_arguments', 'evaluation_arguments',
+    'dataset_arguments', 'Timer'
 ]

--- a/textbox/utils/__init__.py
+++ b/textbox/utils/__init__.py
@@ -1,10 +1,10 @@
 from textbox.utils.logger import init_logger, TensorboardWriter
-from textbox.utils.utils import get_local_time, ensure_dir, get_model, get_trainer, init_seed, Timer
+from textbox.utils.utils import get_local_time, ensure_dir, get_model, get_trainer, init_seed, Timer, ordinal
 from textbox.utils.enum_type import *
 from textbox.utils.argument_list import *
 
 __all__ = [
     'init_logger', 'TensorboardWriter', 'get_local_time', 'ensure_dir', 'get_model', 'get_trainer',
     'Enum', 'ModelType', 'init_seed', 'general_arguments', 'training_arguments', 'evaluation_arguments',
-    'dataset_arguments', 'Timer'
+    'dataset_arguments', 'Timer', 'ordinal'
 ]

--- a/textbox/utils/argument_list.py
+++ b/textbox/utils/argument_list.py
@@ -10,7 +10,7 @@ training_arguments = [
     'epochs', 'train_batch_size', 'learner', 'learning_rate', 'eval_step', 'stopping_step', 'grad_clip',
     'g_pretraining_epochs', 'd_pretraining_epochs', 'd_sample_num', 'd_sample_training_epochs',
     'adversarail_training_epochs', 'adversarail_g_epochs', 'adversarail_d_epochs', 'schedule', 'init_lr',
-    'warmup_steps', 'max_steps'
+    'warmup_steps', 'max_steps', 'valid_metrics'
 ]
 
 evaluation_arguments = ['beam_size', 'decoding_strategy', 'metrics', 'n_grams', 'eval_batch_size']

--- a/textbox/utils/argument_list.py
+++ b/textbox/utils/argument_list.py
@@ -10,7 +10,7 @@ training_arguments = [
     'epochs', 'train_batch_size', 'learner', 'learning_rate', 'eval_step', 'stopping_step', 'grad_clip',
     'g_pretraining_epochs', 'd_pretraining_epochs', 'd_sample_num', 'd_sample_training_epochs',
     'adversarail_training_epochs', 'adversarail_g_epochs', 'adversarail_d_epochs', 'schedule', 'init_lr',
-    'warmup_steps', 'max_steps', 'valid_metrics'
+    'warmup_steps', 'max_steps', 'valid_metrics', 'valid_metrics_factors'
 ]
 
 evaluation_arguments = ['beam_size', 'decoding_strategy', 'metrics', 'n_grams', 'eval_batch_size']

--- a/textbox/utils/argument_list.py
+++ b/textbox/utils/argument_list.py
@@ -7,7 +7,7 @@ general_arguments = [
 ]
 
 training_arguments = [
-    'epochs', 'train_batch_size', 'learner', 'learning_rate', 'eval_step', 'stopping_step', 'grad_clip',
+    'epochs', 'train_batch_size', 'learner', 'learning_rate', 'eval_step', 'eval_epoch', 'stopping_step', 'grad_clip',
     'g_pretraining_epochs', 'd_pretraining_epochs', 'd_sample_num', 'd_sample_training_epochs',
     'adversarail_training_epochs', 'adversarail_g_epochs', 'adversarail_d_epochs', 'schedule', 'init_lr',
     'warmup_steps', 'max_steps', 'valid_metrics', 'valid_metrics_factors'

--- a/textbox/utils/logger.py
+++ b/textbox/utils/logger.py
@@ -27,7 +27,7 @@ class TensorboardWriter:
     writers: List[SummaryWriter] = []
 
     def __init__(self, config):
-        self.dir = config['tensorboard_dir']
+        self.dir = os.path.join(config['tensorboard_dir'], config['filename'])
 
     def __enter__(self):
         self.writers.append(SummaryWriter(log_dir=self.dir))

--- a/textbox/utils/logger.py
+++ b/textbox/utils/logger.py
@@ -10,6 +10,8 @@ textbox.utils.logger
 import logging
 import os
 from textbox.utils.utils import ensure_dir
+from torch.utils.tensorboard import SummaryWriter
+from typing import List
 
 
 log_dir = './log/'
@@ -17,6 +19,28 @@ file_fmt = "%(asctime)-15s %(levelname)s %(message)s"
 file_date_fmt = "%a %d %b %Y %H:%M:%S"
 stream_fmt = "%(asctime)-15s %(levelname)s %(message)s"
 stream_date_fmt = "%d %b %H:%M"
+
+
+class TensorboardWriter:
+    """Automatically initialize and destroy a tensorboard writer."""
+
+    writers: List[SummaryWriter] = []
+
+    def __init__(self, config):
+        self.dir = config['tensorboard_dir']
+
+    def __enter__(self):
+        self.writers.append(SummaryWriter(log_dir=self.dir))
+        return self
+
+    @classmethod
+    def get_writer(cls):
+        return cls.writers[-1]
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.writers[-1].flush()
+        self.writers[-1].close()
+        del self.writers[-1]
 
 
 def init_logger(config, is_logger: bool):

--- a/textbox/utils/utils.py
+++ b/textbox/utils/utils.py
@@ -20,6 +20,29 @@ import random
 import torch
 import numpy as np
 from textbox.utils.enum_type import ModelType, PLM_MODELS
+import time
+
+
+class Timer:
+
+    def __enter__(self):
+        self.__stime = time.time()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.__etime = time.time()
+
+    @property
+    def duration(self):
+        return self.__etime - self.__stime
+
+
+def greater(x, y):
+    return x > y
+
+
+def less(x, y):
+    return x < y
 
 
 def get_local_time():
@@ -41,8 +64,7 @@ def ensure_dir(dir_path):
         dir_path (str): directory path
 
     """
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
+    os.makedirs(dir_path, exist_ok=True)
 
 
 def get_model(model_name):
@@ -90,50 +112,6 @@ def get_trainer(model_type, model_name):
             return getattr(importlib.import_module('textbox.trainer'), 'Seq2SeqTrainer')
         else:
             return getattr(importlib.import_module('textbox.trainer'), 'Trainer')
-
-
-def early_stopping(value, best, cur_step, max_step, bigger=True):
-    r""" validation-based early stopping
-
-    Args:
-        value (float): current result
-        best (float): best result
-        cur_step (int): the number of consecutive steps that did not exceed the best result
-        max_step (int): threshold steps for stopping
-        bigger (bool, optional): whether the bigger the better
-
-    Returns:
-        tuple:
-        - float,
-          best result after this step
-        - int,
-          the number of consecutive steps that did not exceed the best result after this step
-        - bool,
-          whether to stop
-        - bool,
-          whether to update
-    """
-    stop_flag = False
-    update_flag = False
-    if bigger:
-        if value > best:
-            cur_step = 0
-            best = value
-            update_flag = True
-        else:
-            cur_step += 1
-            if cur_step > max_step:
-                stop_flag = True
-    else:
-        if value < best:
-            cur_step = 0
-            best = value
-            update_flag = True
-        else:
-            cur_step += 1
-            if cur_step > max_step:
-                stop_flag = True
-    return best, cur_step, stop_flag, update_flag
 
 
 def init_seed(seed, reproducibility):

--- a/textbox/utils/utils.py
+++ b/textbox/utils/utils.py
@@ -37,14 +37,6 @@ class Timer:
         return self.__etime - self.__stime
 
 
-def greater(x, y):
-    return x > y
-
-
-def less(x, y):
-    return x < y
-
-
 def get_local_time():
     r"""Get current time
 

--- a/textbox/utils/utils.py
+++ b/textbox/utils/utils.py
@@ -21,6 +21,7 @@ import torch
 import numpy as np
 from textbox.utils.enum_type import ModelType, PLM_MODELS
 import time
+from typing import Union
 
 
 class Timer:
@@ -57,6 +58,16 @@ def ensure_dir(dir_path):
 
     """
     os.makedirs(dir_path, exist_ok=True)
+
+
+def ordinal(n: Union[str, int]) -> str:
+    """convert into ordinal number string"""
+    n = int(n)
+    if 11 <= (n % 100) <= 13:
+        suffix = 'th'
+    else:
+        suffix = ['th', 'st', 'nd', 'rd', 'th'][min(n % 10, 4)]
+    return str(n) + suffix
 
 
 def get_model(model_name):


### PR DESCRIPTION
- rename hyperparameter (from previously `eval_step` to `eval_epoch`)
- add new hyperparameters (`valid_metrics`, `valid_metrics_factors`, new `eval_step`)
- support tensorboard for logging loss and validation metrics results
- rename some attributes (`eval_step`, `cur_step` and so on) to disambiguate.
- refactor `_train_epoch()`, `_valid_epoch()` and so on to support new validation mode