### PR TITLE
Fix output information and add new training features

### DIFF
--- a/textbox/config/configurator.py
+++ b/textbox/config/configurator.py
@@ -54,8 +54,8 @@ class Config(object):
         """
         self._init_parameters_category()
         self.yaml_loader = self._build_yaml_loader()
-        self._load_overall_config()
         self.external_sources = list()
+        self._load_overall_config()
         self.file_config_dict = self._load_config_files(config_file_list)
         self.variable_config_dict = self._load_variable_config_dict(config_dict)
         self.cmd_config_dict = self._load_cmd_line()
@@ -121,6 +121,7 @@ class Config(object):
         current_path = os.path.dirname(os.path.realpath(__file__))
         overall_init_file = os.path.join(current_path, '../properties/overall.yaml')
 
+        self.external_sources.append(overall_init_file)
         if os.path.isfile(overall_init_file):
             with open(overall_init_file, 'r', encoding='utf-8') as f:
                 self.overall_config_dict = yaml.load(f.read(), Loader=self.yaml_loader)

--- a/textbox/config/configurator.py
+++ b/textbox/config/configurator.py
@@ -5,7 +5,7 @@ import yaml
 import torch
 from logging import getLogger
 
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union, Iterable
 
 from textbox.utils.utils import get_local_time
 from textbox.utils.argument_list import general_arguments, training_arguments, evaluation_arguments
@@ -240,8 +240,11 @@ class Config(object):
         return final_config_dict
 
     def _simplify_parameter(self, key: str):
-        if key in self.final_config_dict and isinstance(self.final_config_dict[key], str):
-            self.final_config_dict[key] = self.final_config_dict[key].lower()
+        if key in self.final_config_dict:
+            if isinstance(self.final_config_dict[key], str):
+                self.final_config_dict[key] = self.final_config_dict[key].lower()
+            elif isinstance(self.final_config_dict[key], list):
+                self.final_config_dict[key] = [x.lower() for x in self.final_config_dict[key]]
 
     def _set_default_parameters(self):
         self.final_config_dict['dataset'] = self.dataset
@@ -257,6 +260,7 @@ class Config(object):
         self._simplify_parameter('src_lang')
         self._simplify_parameter('tgt_lang')
         self._simplify_parameter('task_type')
+        self._simplify_parameter('metrics_for_best_model')
 
     def _init_device(self):
         if 'use_gpu' not in self.external_config_dict:

--- a/textbox/config/configurator.py
+++ b/textbox/config/configurator.py
@@ -251,6 +251,7 @@ class Config(object):
         self.final_config_dict['filename'] = '{}-{}-{}'.format(
             self.final_config_dict['model'], self.final_config_dict['dataset'], get_local_time()
         )
+        self.final_config_dict['logdir'] = './log/'
         self._simplify_parameter('optimizer')
         self._simplify_parameter('scheduler')
         self._simplify_parameter('src_lang')

--- a/textbox/properties/overall.yaml
+++ b/textbox/properties/overall.yaml
@@ -17,10 +17,7 @@ learning_rate: 3e-5
 eval_epoch: 1
 stopping_steps: 2
 grad_clip: 0.1
-adam_beta1: 0.9
-adam_beta2: 0.999
-epsilon: 1e-8
-weight_decay: 0.01
+optimizer_kwargs: {weight_decay: 0.01}
 accumulation_steps: 1
 
 # evaluation settings

--- a/textbox/quick_start/quick_start.py
+++ b/textbox/quick_start/quick_start.py
@@ -6,6 +6,7 @@ from textbox.utils.logger import init_logger
 from textbox.utils.utils import get_model, get_tokenizer, get_trainer, init_seed
 from textbox.config.configurator import Config
 from textbox.data.utils import data_preparation
+from textbox.utils.dashboard import init_dashboard, finish_dashboard
 
 
 def run_textbox(model=None, dataset=None, config_file_list=None, config_dict=None):
@@ -36,9 +37,8 @@ def run_textbox(model=None, dataset=None, config_file_list=None, config_dict=Non
     set_seed(config['seed'])
 
     # logger initialization
-    is_logger = accelerator.is_local_main_process
-
-    init_logger(config['filename'], config['state'], is_logger)
+    init_logger(config['filename'], config['state'], accelerator.is_local_main_process, config['logdir'])
+    init_dashboard(config)
     logger = getLogger()
     logger.info(config)
 
@@ -89,3 +89,4 @@ def run_textbox(model=None, dataset=None, config_file_list=None, config_dict=Non
         test_result = trainer.evaluate(test_data)
 
     logger.info('test result: {}'.format(test_result))
+    finish_dashboard()

--- a/textbox/trainer/trainer.py
+++ b/textbox/trainer/trainer.py
@@ -360,7 +360,7 @@ class Trainer(AbstractTrainer):
             'best_valid_score': self._best_valid_score,
             'epoch': self.epoch_idx,
             'config': self.config,
-            'summary': self.valid_result_list,
+            'summary': self.valid_result_list[-1],
         }
 
         self.logger.debug(checkpoint)

--- a/textbox/utils/dashboard.py
+++ b/textbox/utils/dashboard.py
@@ -86,7 +86,7 @@ class SummaryTracker:
         for metric, result in results.items():
             self.add_any('metrics/' + metric, result)
             if not isinstance(result, str):
-                self.current_epoch.update_metrics(metric=result)
+                self.current_epoch.update_metrics({metric: result})
 
     @property
     def epoch_score(self) -> float:
@@ -129,7 +129,7 @@ class SummaryTracker:
     def add_corpus(self, tag: str, corpus: Iterable[str]):
         if self._is_local_main_process and not self.tracker_finished:
             corpus = wandb.Table(columns=[tag], data=pd.DataFrame(corpus))
-            #wandb.log({tag: corpus}, step=self._axes[train_step])
+            wandb.log({tag: corpus}, step=self._axes[train_step])
 
     def on_experiment_end(self):
         if self._is_local_main_process:
@@ -262,13 +262,13 @@ class EpochTracker:
         r"""Output loss with epoch and time information."""
         def add_metric(_k, _v):
             _o = ', '
-            if _k in self.metrics_for_best_model:
+            if _k.lower() in self.metrics_for_best_model:
                 _o += '<'
             if isinstance(_v, str):
                 _o += f'{_k}: "{_v[:15]}..."'
             elif isinstance(_v, float):
                 _o += f'{_k}: {_v:.4f}'
-            if _k in self.metrics_for_best_model:
+            if _k.lower() in self.metrics_for_best_model:
                 _o += '>'
             return _o
 

--- a/textbox/utils/dashboard.py
+++ b/textbox/utils/dashboard.py
@@ -41,7 +41,7 @@ class SummaryTracker:
         self.tracker_finished = False
         self.metrics_for_best_model: Set[str] = metrics_for_best_model
 
-        if (self._is_local_main_process):
+        if self._is_local_main_process:
             self._run = wandb.init(**kwargs)
             for axe in axes_label:
                 wandb.define_metric(axe)
@@ -104,7 +104,7 @@ class SummaryTracker:
         self.current_epoch.on_epoch_end()
 
     def add_text(self, tag: str, text_string: str):
-        if (self._is_local_main_process):
+        if self._is_local_main_process:
             if tag not in self._tables:
                 self._tables[tag] = wandb.Table(columns=[train_step, tag])
             self._tables[tag].add_data(self._axes[train_step], text_string)
@@ -112,7 +112,7 @@ class SummaryTracker:
     def add_scalar(self, tag: str, scalar_value: Union[float, int]):
         info = {tag: scalar_value}
         info.update(self._axes)
-        if (self._is_local_main_process):
+        if self._is_local_main_process:
             wandb.log(info, step=self._axes['train/step'])
 
     def add_any(self, tag: str, any_value: Union[str, float, int]):
@@ -122,7 +122,7 @@ class SummaryTracker:
             self.add_scalar(tag, any_value)
 
     def add_corpus(self, tag: str, corpus: Iterable[str]):
-        if (self._is_local_main_process):
+        if self._is_local_main_process:
             corpus = wandb.Table(columns=[tag], data=pd.DataFrame(corpus))
             wandb.log({tag: corpus}, step=self._axes[train_step])
 
@@ -130,9 +130,9 @@ class SummaryTracker:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._email:
-            wandb.alert(title="Training Finished", text="The training is finished.")
         if (self._is_local_main_process):
+            if self._email:
+                wandb.alert(title="Training Finished", text="The training is finished.")
             wandb.log(self._tables)
             self._run.finish()
         self.tracker_finished = True


### PR DESCRIPTION
- Fix output information:
    - Disable forked process warnings from huggingface/tokenizers caused by wandb
        - However, one warning still remains when evaluating rouge value, since `subprocess.check_output()` is used in pyrouge
    - Output detailed validation information of every metrics
- Add new training features:
    - Specify maximal training batch iteration step with `max_steps`
    - Group optimizer parameters into corresponding kwargs dicts, including `optimizer_kwargs`, `adafactor_kwargs` and `scheduler_kwargs`
    - Original `max_steps` for scheduler is now moved under `scheduler_kwargs`