### PR TITLE
Fix: save best file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ facebook/
 .env
 /wandb/
 *.swp
+test/


### PR DESCRIPTION
Improve the logic of `serialized_save`: now `max_save` exactly equals the number of checkpoints to be saved (if possible)